### PR TITLE
Symlinking libruby.so files for system version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Style/SingleSpaceBeforeFirstArg
 name             "swpr_ruby"
 maintainer       "sweeper.io"
 maintainer_email "developers@sweeper.io"
@@ -6,7 +5,6 @@ license          "mit"
 description      "Installs/Configures ruby"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.1.0"
-# rubocop:enable Style/SingleSpaceBeforeFirstArg
 
 supports "ubuntu"
 

--- a/resources/version.rb
+++ b/resources/version.rb
@@ -6,11 +6,21 @@ property :symlink, [TrueClass, FalseClass], default: false
 action :install do
   directory(install_dir) { recursive true }
 
+  libs = ::File.join(install_dir, version, "lib", "libruby.so*")
+  bins = ::File.join(install_dir, version, "bin", "*")
+
+  execute "symlink shared libs #{version}" do
+    action :nothing
+    command "ln -s #{libs} ."
+    cwd "/usr/lib"
+  end
+
   execute "symlink ruby #{version}" do
     action :nothing
-    command "ln -s /opt/rubies/#{version}/bin/* ."
+    command "ln -s #{bins} ."
     cwd "/usr/local/bin"
     only_if { symlink }
+    notifies :run, "execute[symlink shared libs #{version}]", :immediately
   end
 
   ark "ruby-#{version}" do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -18,6 +18,13 @@ describe "swpr_ruby" do
         it { should be_linked_to "/opt/rubies/2.2.3/bin/#{exe}" }
       end
     end
+
+    %w(libruby.so libruby.so.2.2 libruby.so.2.2.0).each do |lib|
+      describe file("/usr/lib/#{lib}") do
+        it { should be_symlink }
+        it { should be_linked_to "/opt/rubies/2.2.3/lib/#{lib}" }
+      end
+    end
   end
 
   context "chruby" do

--- a/test/unit/recipes/default_spec.rb
+++ b/test/unit/recipes/default_spec.rb
@@ -93,6 +93,9 @@ describe "swpr_ruby::default" do
       each_version do |version|
         resource = chef_run.find_resource(:ark, "ruby-#{version}")
         expect(resource).to notify("execute[symlink ruby #{version}]").to(:run).immediately
+
+        resource = chef_run.find_resource(:execute, "symlink ruby #{version}")
+        expect(resource).to notify("execute[symlink shared libs #{version}]").to(:run).immediately
       end
     end
   end


### PR DESCRIPTION
Fixes #1 
# The Problem

Since we're just grabbing precompiled rubies, we have to do a couple of things manually. On top of symlinking the binaries, we should also symlink the shared libs (used to compile vim from source for example).
# The Solution

Symlink those libs...
